### PR TITLE
Fix version number to upload to PyPI

### DIFF
--- a/todo/__init__.py
+++ b/todo/__init__.py
@@ -1,5 +1,5 @@
 """django todo"""
-__version__ = '1.4.dev'
+__version__ = '1.4'
 
 __author__ = 'Scot Hacker'
 __email__ = 'shacker@birdhouse.org'


### PR DESCRIPTION
This should fix the `pip install` problem of the PyPI package as described on [StackOverflow](http://stackoverflow.com/questions/26819350/pip-not-getting-current-version/). After merging this PR you'd have to:
1. Delete the not-working 1.4 package from PyPi (manually in the web interface), and
2. Run `./setup.py sdist upload` (after authenticating via `./setup.py register` beforehand, naturally)

I've done this for you already (to test that it works, really), and `pip install django-todo` now works fine.
