### PR TITLE
Add utf-8 slugs for lists and fix a typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     tests_require=['tox'],
+    install_requires=['django-autoslug', 'unidecode', ],
     cmdclass={
         'clean': Clean,
         'test': Tox,

--- a/todo/models.py
+++ b/todo/models.py
@@ -3,23 +3,17 @@ import datetime
 
 from django.db import models
 from django.contrib.auth.models import Group
-from django.template.defaultfilters import slugify
 from django.core.urlresolvers import reverse
 from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
+from autoslug import AutoSlugField
 
 
 @python_2_unicode_compatible
 class List(models.Model):
     name = models.CharField(max_length=60)
-    slug = models.SlugField(max_length=60, editable=False)
+    slug = AutoSlugField(populate_from='name', editable=False, always_update=True)
     group = models.ForeignKey(Group)
-
-    def save(self, *args, **kwargs):
-        if not self.id:
-            self.slug = slugify(self.name)
-
-        super(List, self).save(*args, **kwargs)
 
     def __str__(self):
         return self.name

--- a/todo/views.py
+++ b/todo/views.py
@@ -71,7 +71,7 @@ def del_list(request, list_id, list_slug):
 
     if request.method == 'POST':
         List.objects.get(id=list.id).delete()
-        messages.success(request, "{list_name} is gone.".format(list_name=del_list.name))
+        messages.success(request, "{list_name} is gone.".format(list_name=list.name))
         return HttpResponseRedirect(reverse('todo-lists'))
     else:
         item_count_done = Item.objects.filter(list=list.id, completed=1).count()


### PR DESCRIPTION
I tried adding a list with only Greek characters in its name, and the resulting slug was an empty string as Django only allows ascii characters. This caused a `NoReverseMatch` error when trying to view the lists.

This adds a dependency for the autoslug package. An alternative would be to check for zero length slugs and add an alternative representation (perhaps replace all non-ascii chars with '_' or '-').

I also corrected a typo in `views.py:del_list()`