### PR TITLE
Prevent occasional crash during task re-ordering

### DIFF
--- a/todo/views/reorder_tasks.py
+++ b/todo/views/reorder_tasks.py
@@ -20,10 +20,15 @@ def reorder_tasks(request) -> HttpResponse:
         # Re-prioritize each task in list
         i = 1
         for id in newtasklist:
-            task = Task.objects.get(pk=id)
-            task.priority = i
-            task.save()
-            i += 1
+            try:
+                task = Task.objects.get(pk=id)
+                task.priority = i
+                task.save()
+                i += 1
+            except Task.DoesNotExist:
+                # Can occur if task is deleted behind the scenes during re-ordering.
+                # Not easy to remove it from the UI without page refresh, but prevent crash.
+                pass
 
     # All views must return an httpresponse of some kind ... without this we get
     # error 500s in the log even though things look peachy in the browser.


### PR DESCRIPTION
Fixes #58 : Back-end crash when the task db refreshes and a demo user tries to re-order a task list they're currently viewing.