### PR TITLE
Add missing name="notify"

### DIFF
--- a/todo/templates/todo/include/task_edit.html
+++ b/todo/templates/todo/include/task_edit.html
@@ -32,7 +32,7 @@
 
     <div class="form-group">
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" aria-describedby="inputNotifyHelp" checked="checked" id="id_notify">
+        <input name="notify" class="form-check-input" type="checkbox" aria-describedby="inputNotifyHelp" checked="checked" id="id_notify">
         <label class="form-check-label" for="id_notify">
           Notify
         </label>


### PR DESCRIPTION
The `<input>` was not marked with `name="notify"`, so the [`"notify" in request.POST` condition](https://github.com/shacker/django-todo/blob/master/todo/views/list_detail.py#L60) was always `False`.

Please let me know if you have any feedback, thanks!