### PR TITLE
Signals demo - do not merge

### DIFF
--- a/todo/signals.py
+++ b/todo/signals.py
@@ -1,0 +1,24 @@
+import django.dispatch
+from django.dispatch import receiver
+
+from todo.utils import toggle_task_completed
+
+# ### REGISTER SIGNALS ###
+
+# Demonstrates registering a custom signal
+pizza_done = django.dispatch.Signal(providing_args=["toppings", "size", "task_id"])
+
+
+# ### HANDLE SIGNALS ###
+
+# Demonstrates receiving a custom signal
+# (which in turn calls an existing todo function, but could do anything)
+@receiver(pizza_done)
+def toggle_task_handler(sender, **kwargs):
+    print(sender)
+    print(kwargs)
+    task_id = kwargs.get("task_id")
+    results = toggle_task_completed(task_id)
+    print(results)
+
+    print("Request finished!")

--- a/todo/views/list_lists.py
+++ b/todo/views/list_lists.py
@@ -9,12 +9,18 @@ from todo.forms import SearchForm
 from todo.models import Task, TaskList
 from todo.utils import staff_check
 
+from todo.signals import pizza_done
 
 @login_required
 @user_passes_test(staff_check)
 def list_lists(request) -> HttpResponse:
     """Homepage view - list of lists a user can view, and ability to add a list.
     """
+
+    # Demonstrates sending a custom signal from elsewhere in the project.
+    # In this case when the list of lists is viewed, I'm going to toggle
+    # the "completed" state of task 150 (just for example's sake).
+    pizza_done.send(sender="foobar", toppings=["anchovies", "parmesan"], size=7, task_id=150)
 
     thedate = datetime.datetime.now()
     searchform = SearchForm(auto_id=False)


### PR DESCRIPTION
Bare bones example of registering a custom signal in a django app, then calling it from somewhere else. In this case, accessing the list of lists toggles the "done" status of task 150. Provided as a starter reference to demonstrate the flexibility of signals.

Try opening task 150 in a separate tab. Then in your first tab view the list of lists. Then refresh tab #2 to see that the "completed" status of task 150 has toggled.