### PR TITLE
Delete perms: must be staff and in group

### DIFF
--- a/todo/tests/test_views.py
+++ b/todo/tests/test_views.py
@@ -62,13 +62,6 @@ def test_view_list(todo_setup, admin_client):
     assert response.status_code == 200
 
 
-def test_del_list(todo_setup, admin_client):
-    tlist = TaskList.objects.get(slug="zip")
-    url = reverse("todo:del_list", kwargs={"list_id": tlist.id, "list_slug": tlist.slug})
-    response = admin_client.get(url)
-    assert response.status_code == 200
-
-
 def test_view_add_list(todo_setup, admin_client):
     url = reverse("todo:add_list")
     response = admin_client.get(url)
@@ -180,6 +173,13 @@ def test_view_del_list_nonadmin(todo_setup, client):
     client.login(username="you", password="password")
     response = client.get(url)
     assert response.status_code == 302  # Fedirected to login
+
+
+def test_del_list_not_in_list_group(todo_setup, admin_client):
+    tlist = TaskList.objects.get(slug="zip")
+    url = reverse("todo:del_list", kwargs={"list_id": tlist.id, "list_slug": tlist.slug})
+    response = admin_client.get(url)
+    assert response.status_code == 403
 
 
 def test_view_list_mine(todo_setup, client):

--- a/todo/views/del_list.py
+++ b/todo/views/del_list.py
@@ -17,7 +17,9 @@ def del_list(request, list_id: int, list_slug: str) -> HttpResponse:
 
     # Ensure user has permission to delete list. Get the group this list belongs to,
     # and check whether current user is a member of that group AND a staffer.
-    if not (task_list.group in request.user.groups.all() and request.user.is_staff):
+    if task_list.group not in request.user.groups.all():
+        raise PermissionDenied    
+    if not request.user.is_staff:
         raise PermissionDenied
 
     if request.method == "POST":

--- a/todo/views/del_list.py
+++ b/todo/views/del_list.py
@@ -17,7 +17,7 @@ def del_list(request, list_id: int, list_slug: str) -> HttpResponse:
 
     # Ensure user has permission to delete list. Get the group this list belongs to,
     # and check whether current user is a member of that group AND a staffer.
-    if task_list.group not in request.user.groups.all() and not request.user.is_staff:
+    if not (task_list.group in request.user.groups.all() and request.user.is_staff):
         raise PermissionDenied
 
     if request.method == "POST":


### PR DESCRIPTION
AFAICT, this change makes the code match the intended behavior described in the comment:

```
# Ensure user has permission to delete list. Get the group this list belongs to,
# and check whether current user is a member of that group AND a staffer.
```

before this change, a staffer could delete any list.

Example evaluation of the part after the `and`:

```python
task_list.group not in request.user.groups.all() and not request.user.is_staff
# ...evaluates to...
task_list.group not in request.user.groups.all() and not True
# ...evaluates to...
task_list.group not in request.user.groups.all() and False
# ...evaluates to...
False
```