### PR TITLE
Skip module check because it blocks automated installs

### DIFF
--- a/todo/__init__.py
+++ b/todo/__init__.py
@@ -10,6 +10,9 @@ __url__ = "https://github.com/shacker/django-todo"
 __license__ = "BSD License"
 
 try:
+	# if django is not installed,
+	# skips check because it blocks automated installs
+	import django
 	from . import check
 except ModuleNotFoundError:
 	# this can happen during install time, if django is not installed yet!


### PR DESCRIPTION
My idea was import django before the check.py to skip the blocking error. Any feedback will be appreciated.

![2022-01-26_18-31-django-todo](https://user-images.githubusercontent.com/290350/151256810-9d88f62b-de80-4950-8d09-0db4a0e4ba05.png)
